### PR TITLE
feat: 북마크와 대시보드를 포함한 계획 관리 기능 구현

### DIFF
--- a/backend/src/main/java/com/ssafy/where2meow/common/util/UuidUserUtil.java
+++ b/backend/src/main/java/com/ssafy/where2meow/common/util/UuidUserUtil.java
@@ -4,12 +4,14 @@ import com.ssafy.where2meow.exception.EntityNotFoundException;
 import com.ssafy.where2meow.user.entity.User;
 import com.ssafy.where2meow.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UuidUserUtil {

--- a/backend/src/main/java/com/ssafy/where2meow/config/CorsConfig.java
+++ b/backend/src/main/java/com/ssafy/where2meow/config/CorsConfig.java
@@ -1,30 +1,30 @@
-package com.ssafy.where2meow.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-@Configuration
-public class CorsConfig implements WebMvcConfigurer {
-
-  @Override
-  public void addCorsMappings(CorsRegistry registry) {
-    registry.addMapping("/**")
-        .allowedOrigins("http://127.0.0.1:5173", "http://127.0.0.1:8000",
-            "http://localhost:5173", "http://localhost:8000")
-        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD")
-        .allowedHeaders("*")  // 모든 헤더 허용
-        .allowCredentials(true)
-        .maxAge(3600);  // preflight 캐시 시간
-  }
-}
-
-
-
-
-
-
-
-
-
-
+//package com.ssafy.where2meow.config;
+//
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.web.servlet.config.annotation.CorsRegistry;
+//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+//
+//@Configuration
+//public class CorsConfig implements WebMvcConfigurer {
+//
+//  @Override
+//  public void addCorsMappings(CorsRegistry registry) {
+//    registry.addMapping("/**")
+//        .allowedOrigins("http://127.0.0.1:5173", "http://127.0.0.1:8000",
+//            "http://localhost:5173", "http://localhost:8000")
+//        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD")
+//        .allowedHeaders("*")  // 모든 헤더 허용
+//        .allowCredentials(true)
+//        .maxAge(3600);  // preflight 캐시 시간
+//  }
+//}
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//

--- a/backend/src/main/java/com/ssafy/where2meow/config/CorsConfig.java
+++ b/backend/src/main/java/com/ssafy/where2meow/config/CorsConfig.java
@@ -10,12 +10,15 @@ public class CorsConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/**")
-        .allowedOrigins("http://127.0.0.1:5173", "http://127.0.0.1:8000")
-        .allowedMethods("*")
-        .allowCredentials(true);
+        .allowedOrigins("http://127.0.0.1:5173", "http://127.0.0.1:8000",
+            "http://localhost:5173", "http://localhost:8000")
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD")
+        .allowedHeaders("*")  // 모든 헤더 허용
+        .allowCredentials(true)
+        .maxAge(3600);  // preflight 캐시 시간
   }
-
 }
+
 
 
 

--- a/backend/src/main/java/com/ssafy/where2meow/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ssafy/where2meow/config/SecurityConfig.java
@@ -119,7 +119,7 @@ public class SecurityConfig {
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedOriginPatterns(Arrays.asList("*"));
-    configuration.setAllowedMethods(Arrays.asList("HEAD", "POST", "GET", "DELETE", "PUT", "OPTIONS"));
+    configuration.setAllowedMethods(Arrays.asList("POST", "GET", "DELETE", "PUT"));
     configuration.setAllowedHeaders(Arrays.asList("*"));
     configuration.setAllowCredentials(true);
 

--- a/backend/src/main/java/com/ssafy/where2meow/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ssafy/where2meow/config/SecurityConfig.java
@@ -18,6 +18,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -51,6 +56,7 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
+        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
         .csrf(csrf -> csrf.disable())
         .formLogin(formLogin -> formLogin.disable())
         .httpBasic(httpBasic -> httpBasic.disable())
@@ -106,6 +112,20 @@ public class SecurityConfig {
   @Bean
   public LoginCookie cookieUtil() {
     return new LoginCookie();
+  }
+
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOriginPatterns(Arrays.asList("*"));
+    configuration.setAllowedMethods(Arrays.asList("HEAD", "POST", "GET", "DELETE", "PUT", "OPTIONS"));
+    configuration.setAllowedHeaders(Arrays.asList("*"));
+    configuration.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
   }
 
   @Bean

--- a/backend/src/main/java/com/ssafy/where2meow/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/ssafy/where2meow/plan/controller/PlanController.java
@@ -7,10 +7,12 @@ import com.ssafy.where2meow.plan.dto.PlanResponse;
 import com.ssafy.where2meow.plan.service.PlanBookmarkService;
 import com.ssafy.where2meow.plan.service.PlanLikeService;
 import com.ssafy.where2meow.plan.service.PlanService;
+import com.ssafy.where2meow.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,6 +29,7 @@ public class PlanController {
     private final PlanService planService;
     private final PlanLikeService planLikeService;
     private final PlanBookmarkService planBookmarkService;
+    private final UserService userService;
 
     private final UuidUserUtil uuidUserUtil;
 
@@ -179,6 +182,18 @@ public class PlanController {
 
         planBookmarkService.deleteBookmarkByUuid(planId, uuid);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/bookmarks")
+    public ResponseEntity<List<PlanResponse>> getBookmarkedPlans() {
+        try {
+            UUID uuid = uuidUserUtil.getCurrentUserUuid();
+            int userId = userService.getUserIdByUuid(uuid);
+            List<PlanResponse> bookmarkedPlans = planService.getBookmarkedPlans(userId);
+            return ResponseEntity.ok(bookmarkedPlans);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
 }

--- a/backend/src/main/java/com/ssafy/where2meow/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/ssafy/where2meow/plan/controller/PlanController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +21,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/plan")
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/ssafy/where2meow/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/ssafy/where2meow/plan/controller/PlanController.java
@@ -28,174 +28,175 @@ import java.util.UUID;
 @Tag(name = "Plan", description = "여행 계획 관리 API")
 public class PlanController {
 
-    private final PlanService planService;
-    private final PlanLikeService planLikeService;
-    private final PlanBookmarkService planBookmarkService;
-    private final UserService userService;
+  private final PlanService planService;
+  private final PlanLikeService planLikeService;
+  private final PlanBookmarkService planBookmarkService;
+  private final UserService userService;
 
-    private final UuidUserUtil uuidUserUtil;
+  private final UuidUserUtil uuidUserUtil;
 
-    @GetMapping
-    @Operation(
-            summary = "여행 계획 리스트 조회",
-            description = "여행 계획 리스트를 조회합니다. (로그인되어 있다면 본인이 생성한 private 여행 계획도 포함)"
-    )
-    @ApiResponse(responseCode = "200", description = "여행 계획 리스트 조회 성공")
-    public ResponseEntity<List<PlanResponse>> getAllPlans() {
-        // 인증 정보 추출
-        UUID uuid = uuidUserUtil.getCurrentUserUuid();
+  @GetMapping
+  @Operation(
+      summary = "여행 계획 리스트 조회",
+      description = "여행 계획 리스트를 조회합니다. (로그인되어 있다면 본인이 생성한 private 여행 계획도 포함)"
+  )
+  @ApiResponse(responseCode = "200", description = "여행 계획 리스트 조회 성공")
+  public ResponseEntity<List<PlanResponse>> getAllPlans() {
+    // 인증 정보 추출
+    UUID uuid = uuidUserUtil.getCurrentUserUuid();
 
-        List<PlanResponse> plans = planService.getAllPlansByUuid(uuid);
-        return ResponseEntity.ok(plans);
-    }
+    List<PlanResponse> plans = planService.getAllPlansByUuid(uuid);
+    return ResponseEntity.ok(plans);
+  }
 
-    @GetMapping("/user")
-    @Operation(
-            summary = "여행 계획 리스트 조회 (사용자)",
-            description = "사용자가 생성한 여행 계획 리스트를 조회합니다."
-    )
-    @ApiResponse(responseCode = "200", description = "여행 계획 리스트 조회 성공")
-    public ResponseEntity<List<PlanResponse>> getUserPlans() {
-        // 인증 정보 추출
-        UUID uuid = uuidUserUtil.getCurrentUserUuid();
+  @GetMapping("/user")
+  @Operation(
+      summary = "여행 계획 리스트 조회 (사용자)",
+      description = "사용자가 생성한 여행 계획 리스트를 조회합니다."
+  )
+  @ApiResponse(responseCode = "200", description = "여행 계획 리스트 조회 성공")
+  public ResponseEntity<List<PlanResponse>> getUserPlans() {
+    // 인증 정보 추출
+    UUID uuid = uuidUserUtil.getCurrentUserUuid();
 
-        List<PlanResponse> plans = planService.getUserPlansByUuid(uuid);
-        return ResponseEntity.ok(plans);
-    }
+    List<PlanResponse> plans = planService.getUserPlansByUuid(uuid);
+    return ResponseEntity.ok(plans);
+  }
 
-    @GetMapping("/{planId}")
-    @Operation(
-            summary = "여행 계획 상세 조회",
-            description = "여행 계획의 상세 정보를 조회합니다."
-    )
-    @ApiResponse(responseCode = "200", description = "여행 계획 상세 조회 성공")
-    @ApiResponse(responseCode = "404", description = "여행 계획을 찾을 수 없음")
-    public ResponseEntity<PlanDetailResponse> getPlanDetail(@PathVariable int planId) {
-        // 인증 정보 추출
-        UUID uuid = uuidUserUtil.getCurrentUserUuid();
+  @GetMapping("/{planId}")
+  @Operation(
+      summary = "여행 계획 상세 조회",
+      description = "여행 계획의 상세 정보를 조회합니다."
+  )
+  @ApiResponse(responseCode = "200", description = "여행 계획 상세 조회 성공")
+  @ApiResponse(responseCode = "404", description = "여행 계획을 찾을 수 없음")
+  public ResponseEntity<PlanDetailResponse> getPlanDetail(@PathVariable int planId) {
+    // 인증 정보 추출
+    UUID uuid = uuidUserUtil.getCurrentUserUuid();
 
-        PlanDetailResponse planDetail = planService.getPlanDetailByUuid(planId, uuid);
-        return ResponseEntity.ok(planDetail);
-    }
+    PlanDetailResponse planDetail = planService.getPlanDetailByUuid(planId, uuid);
+    return ResponseEntity.ok(planDetail);
+  }
 
-    @PostMapping
-    @Operation(
-            summary = "여행 계획 추가",
-            description = "여행 계획을 추가합니다."
-    )
-    @ApiResponse(responseCode = "201", description = "여행 계획 추가 성공")
-    public ResponseEntity<PlanResponse> createPlan(@RequestBody PlanRequest planRequest) {
-        // 인증 정보 추출
-        UUID uuid = uuidUserUtil.getCurrentUserUuid();
+  @PostMapping
+  @Operation(
+      summary = "여행 계획 추가",
+      description = "여행 계획을 추가합니다."
+  )
+  @ApiResponse(responseCode = "201", description = "여행 계획 추가 성공")
+  public ResponseEntity<PlanResponse> createPlan(@RequestBody PlanRequest planRequest) {
+    // 인증 정보 추출
+    UUID uuid = uuidUserUtil.getCurrentUserUuid();
 
-        PlanResponse createdPlan = planService.createPlanByUuid(planRequest, uuid);
-        URI location = URI.create("/api/plan/" + createdPlan.getPlanId());
-        return ResponseEntity.created(location).body(createdPlan);
-    }
+    PlanResponse createdPlan = planService.createPlanByUuid(planRequest, uuid);
+    URI location = URI.create("/api/plan/" + createdPlan.getPlanId());
+    return ResponseEntity.created(location).body(createdPlan);
+  }
 
-    @PutMapping("/{planId}")
-    @Operation(
-            summary = "여행 계획 수정",
-            description = "여행 계획을 수정합니다."
-    )
-    @ApiResponse(responseCode = "200", description = "여행 계획 수정 성공")
-    @ApiResponse(responseCode = "403", description = "여행 계획 수정 권한 없음")
-    @ApiResponse(responseCode = "404", description = "여행 계획을 찾을 수 없음")
-    public ResponseEntity<PlanResponse> updatePlan(
-            @PathVariable int planId, @RequestBody PlanRequest planRequest) {
-        // 인증 정보 추출
-        UUID uuid = uuidUserUtil.getCurrentUserUuid();
+  @PutMapping("/{planId}")
+  @Operation(
+      summary = "여행 계획 수정",
+      description = "여행 계획을 수정합니다."
+  )
+  @ApiResponse(responseCode = "200", description = "여행 계획 수정 성공")
+  @ApiResponse(responseCode = "403", description = "여행 계획 수정 권한 없음")
+  @ApiResponse(responseCode = "404", description = "여행 계획을 찾을 수 없음")
+  public ResponseEntity<PlanResponse> updatePlan(
+      @PathVariable int planId, @RequestBody PlanRequest planRequest) {
+    // 인증 정보 추출
+    UUID uuid = uuidUserUtil.getCurrentUserUuid();
 
-        PlanResponse updatedPlan = planService.updatePlanByUuid(planId, planRequest, uuid);
-        return ResponseEntity.ok(updatedPlan);
-    }
+    PlanResponse updatedPlan = planService.updatePlanByUuid(planId, planRequest, uuid);
+    return ResponseEntity.ok(updatedPlan);
+  }
 
-    @DeleteMapping("/{planId}")
-    @Operation(
-            summary = "여행 계획 삭제",
-            description = "여행 계획을 삭제합니다."
-    )
-    @ApiResponse(responseCode = "204", description = "여행 계획 삭제 성공")
-    @ApiResponse(responseCode = "403", description = "여행 계획 삭제 권한 없음")
-    @ApiResponse(responseCode = "404", description = "여행 계획을 찾을 수 없음")
-    public ResponseEntity<Void> deletePlan(@PathVariable int planId) {
-        // 인증된 사용자 확인
-        UUID uuid = uuidUserUtil.getCurrentUserUuid();
+  @DeleteMapping("/{planId}")
+  @Operation(
+      summary = "여행 계획 삭제",
+      description = "여행 계획을 삭제합니다."
+  )
+  @ApiResponse(responseCode = "204", description = "여행 계획 삭제 성공")
+  @ApiResponse(responseCode = "403", description = "여행 계획 삭제 권한 없음")
+  @ApiResponse(responseCode = "404", description = "여행 계획을 찾을 수 없음")
+  public ResponseEntity<Void> deletePlan(@PathVariable int planId) {
+    // 인증된 사용자 확인
+    UUID uuid = uuidUserUtil.getCurrentUserUuid();
 
-        planService.deletePlanByUuid(planId, uuid);
-        return ResponseEntity.noContent().build();
-    }
+    planService.deletePlanByUuid(planId, uuid);
+    return ResponseEntity.noContent().build();
+  }
 
-    // 여행 계획 좋아요 추가
-    @PostMapping("/{planId}/like")
-    @Operation(
-            summary = "여행 계획 좋아요 추가",
-            description = "로그인한 사용자가 특정 여행 계획에 좋아요를 추가합니다."
-    )
-    @ApiResponse(responseCode = "204", description = "여행 계획 좋아요 추가 성공")
-    public ResponseEntity<Void> createLike(@PathVariable int planId) {
-        // 인증된 사용자 확인
-        UUID uuid = uuidUserUtil.getCurrentUserUuid();
+  // 여행 계획 좋아요 추가
+  @PostMapping("/{planId}/like")
+  @Operation(
+      summary = "여행 계획 좋아요 추가",
+      description = "로그인한 사용자가 특정 여행 계획에 좋아요를 추가합니다."
+  )
+  @ApiResponse(responseCode = "204", description = "여행 계획 좋아요 추가 성공")
+  public ResponseEntity<Void> createLike(@PathVariable int planId) {
+    // 인증된 사용자 확인
+    UUID uuid = uuidUserUtil.getCurrentUserUuid();
 
-        planLikeService.createLikeByUuid(planId, uuid);
-        return ResponseEntity.noContent().build();
-    }
+    planLikeService.createLikeByUuid(planId, uuid);
+    return ResponseEntity.noContent().build();
+  }
 
-    // 여행 계획 좋아요 삭제
-    @DeleteMapping("/{planId}/like")
-    @Operation(
-            summary = "여행 계획 좋아요 삭제",
-            description = "로그인한 사용자가 특정 여행 계획의 좋아요를 삭제합니다."
-    )
-    @ApiResponse(responseCode = "204", description = "여행 계획 좋아요 삭제 성공")
-    public ResponseEntity<Void> deleteLike(@PathVariable int planId) {
-        // 인증된 사용자 확인
-        UUID uuid = uuidUserUtil.getCurrentUserUuid();
+  // 여행 계획 좋아요 삭제
+  @DeleteMapping("/{planId}/like")
+  @Operation(
+      summary = "여행 계획 좋아요 삭제",
+      description = "로그인한 사용자가 특정 여행 계획의 좋아요를 삭제합니다."
+  )
+  @ApiResponse(responseCode = "204", description = "여행 계획 좋아요 삭제 성공")
+  public ResponseEntity<Void> deleteLike(@PathVariable int planId) {
+    // 인증된 사용자 확인
+    UUID uuid = uuidUserUtil.getCurrentUserUuid();
 
-        planLikeService.deleteLikeByUuid(planId, uuid);
-        return ResponseEntity.noContent().build();
-    }
+    planLikeService.deleteLikeByUuid(planId, uuid);
+    return ResponseEntity.noContent().build();
+  }
 
-    // 여행 계획 북마크 추가
-    @PostMapping("/{planId}/bookmark")
-    @Operation(
-            summary = "여행 계획 북마크 추가",
-            description = "로그인한 사용자가 특정 여행 계획에 북마크를 추가합니다."
-    )
-    @ApiResponse(responseCode = "204", description = "여행 계획 북마크 추가 성공")
-    public ResponseEntity<Void> createBookmark(@PathVariable int planId) {
-        // 인증된 사용자 확인
-        UUID uuid = uuidUserUtil.getCurrentUserUuid();
+  // 여행 계획 북마크 추가
+  @PostMapping("/{planId}/bookmark")
+  @Operation(
+      summary = "여행 계획 북마크 추가",
+      description = "로그인한 사용자가 특정 여행 계획에 북마크를 추가합니다."
+  )
+  @ApiResponse(responseCode = "204", description = "여행 계획 북마크 추가 성공")
+  public ResponseEntity<Void> createBookmark(@PathVariable int planId) {
+    // 인증된 사용자 확인
+    UUID uuid = uuidUserUtil.getCurrentUserUuid();
 
-        planBookmarkService.createBookmarkByUuid(planId, uuid);
-        return ResponseEntity.noContent().build();
-    }
+    planBookmarkService.createBookmarkByUuid(planId, uuid);
+    return ResponseEntity.noContent().build();
+  }
 
-    // 여행 계획 북마크 삭제
-    @DeleteMapping("/{planId}/bookmark")
-    @Operation(
-            summary = "여행 계획 북마크 삭제",
-            description = "로그인한 사용자가 특정 여행 계획의 북마크를 삭제합니다."
-    )
-    @ApiResponse(responseCode = "204", description = "여행 계획 북마크 삭제 성공")
-    public ResponseEntity<Void> deleteBookmark(@PathVariable int planId) {
-        // 인증된 사용자 확인
-        UUID uuid = uuidUserUtil.getCurrentUserUuid();
+  // 여행 계획 북마크 삭제
+  @DeleteMapping("/{planId}/bookmark")
+  @Operation(
+      summary = "여행 계획 북마크 삭제",
+      description = "로그인한 사용자가 특정 여행 계획의 북마크를 삭제합니다."
+  )
+  @ApiResponse(responseCode = "204", description = "여행 계획 북마크 삭제 성공")
+  public ResponseEntity<Void> deleteBookmark(@PathVariable int planId) {
+    // 인증된 사용자 확인
+    UUID uuid = uuidUserUtil.getCurrentUserUuid();
 
-        planBookmarkService.deleteBookmarkByUuid(planId, uuid);
-        return ResponseEntity.noContent().build();
-    }
+    planBookmarkService.deleteBookmarkByUuid(planId, uuid);
+    return ResponseEntity.noContent().build();
+  }
 
-    @GetMapping("/bookmarks")
-    public ResponseEntity<List<PlanResponse>> getBookmarkedPlans() {
-        try {
-            UUID uuid = uuidUserUtil.getCurrentUserUuid();
-            int userId = userService.getUserIdByUuid(uuid);
-            List<PlanResponse> bookmarkedPlans = planService.getBookmarkedPlans(userId);
-            return ResponseEntity.ok(bookmarkedPlans);
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
-        }
-    }
+  @Operation(
+      summary = "북마크한 여행 계획 목록 조회",
+      description = "로그인한 사용자가 북마크한 여행 계획 목록을 조회합니다."
+  )
+  @ApiResponse(responseCode = "200", description = "북마크한 여행 계획 목록 조회 성공")
+  @GetMapping("/bookmarks")
+  public ResponseEntity<List<PlanResponse>> getBookmarkedPlans() {
+    UUID uuid = uuidUserUtil.getCurrentUserUuid();
+    int userId = userService.getUserIdByUuid(uuid);
+    List<PlanResponse> bookmarkedPlans = planService.getBookmarkedPlans(userId);
+    return ResponseEntity.ok(bookmarkedPlans);
+  }
 
 }

--- a/backend/src/main/java/com/ssafy/where2meow/plan/dto/PlanResponse.java
+++ b/backend/src/main/java/com/ssafy/where2meow/plan/dto/PlanResponse.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class PlanResponse {
     private int planId;
     private int userId;

--- a/backend/src/main/java/com/ssafy/where2meow/plan/repository/PlanRepository.java
+++ b/backend/src/main/java/com/ssafy/where2meow/plan/repository/PlanRepository.java
@@ -1,11 +1,14 @@
 package com.ssafy.where2meow.plan.repository;
 
 import com.ssafy.where2meow.plan.entity.Plan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface PlanRepository extends JpaRepository<Plan, Integer> {
 
@@ -24,4 +27,15 @@ public interface PlanRepository extends JpaRepository<Plan, Integer> {
     @Query("UPDATE Plan p SET p.viewCount = p.viewCount + 1 WHERE p.planId = :planId")
     void increaseViewCount(int planId);
 
+    @Query("SELECT p FROM Plan p " +
+        "JOIN PlanBookmark pb ON p.planId = pb.planId " +
+        "WHERE pb.userId = :userId " +
+        "ORDER BY pb.bookmarkedAt DESC")
+    List<Plan> findBookmarkedPlansByUserId(int userId);
+
+    @Query("SELECT p FROM Plan p " +
+        "JOIN PlanBookmark pb ON p.planId = pb.planId " +
+        "WHERE pb.userId = :userId " +
+        "ORDER BY pb.bookmarkedAt DESC")
+    Page<Plan> findBookmarkedPlansByUserId(int userId, Pageable pageable);
 }

--- a/backend/src/main/java/com/ssafy/where2meow/plan/service/PlanService.java
+++ b/backend/src/main/java/com/ssafy/where2meow/plan/service/PlanService.java
@@ -17,6 +17,8 @@ import com.ssafy.where2meow.plan.repository.PlanRepository;
 import com.ssafy.where2meow.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -286,6 +288,53 @@ public class PlanService {
         if (plan.getUserId() != userId) {
             throw new ForbiddenAccessException("이 여행 계획에 대한 권한이 없습니다.");
         }
+    }
+
+    @Transactional
+    public List<PlanResponse> getBookmarkedPlans(int userId) {
+        List<Plan> bookmarkedPlans = planRepository.findBookmarkedPlansByUserId(userId);
+
+        return bookmarkedPlans.stream()
+            .map(plan -> {
+                PlanResponse dto = convertToPlanResponse(plan);
+                // 북마크된 계획이므로 bookmarked = true
+                dto.setBookmarked(true);
+                // 좋아요 여부 확인
+                dto.setLiked(planLikeRepository.existsByPlanIdAndUserId(plan.getPlanId(), userId));
+                return dto;
+            })
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public Page<PlanResponse> getBookmarkedPlans(int userId, Pageable pageable) {
+        Page<Plan> bookmarkedPlans = planRepository.findBookmarkedPlansByUserId(userId, pageable);
+
+        return bookmarkedPlans.map(plan -> {
+            PlanResponse dto = convertToPlanResponse(plan);
+            dto.setBookmarked(true);
+            dto.setLiked(planLikeRepository.existsByPlanIdAndUserId(plan.getPlanId(), userId));
+            return dto;
+        });
+    }
+
+    /**
+     * Plan 엔티티를 PlanResponseDto로 변환
+     */
+    private PlanResponse convertToPlanResponse(Plan plan) {
+        return PlanResponse.builder()
+            .planId(plan.getPlanId())
+            .userId(plan.getUserId())
+            .title(plan.getTitle())
+            .content(plan.getContent())
+            .createdAt(plan.getCreatedAt())
+            .updatedAt(plan.getUpdatedAt())
+            .startDate(plan.getStartDate())
+            .endDate(plan.getEndDate())
+            .viewCount(plan.getViewCount())
+            .likeCount(planLikeRepository.countByPlanId(plan.getPlanId()))
+            .isPublic(plan.isPublic())
+            .build();
     }
 
 }

--- a/backend/src/main/java/com/ssafy/where2meow/user/service/UserService.java
+++ b/backend/src/main/java/com/ssafy/where2meow/user/service/UserService.java
@@ -73,6 +73,13 @@ public class UserService {
     return UserResponse.fromEntity(user);
   }
 
+  public int getUserIdByUuid(UUID uuid) {
+    User user = userRepository.findByUuidAndIsActiveTrue(uuid)
+        .orElseThrow(() -> new UserNotFoundException(uuid));
+
+    return user.getUserId();
+  }
+
   /**
    * 사용자 정보 수정
    *

--- a/frontend/src/api/plan.js
+++ b/frontend/src/api/plan.js
@@ -23,7 +23,12 @@ planAPiClient.interceptors.response.use(
     if (error.response?.status === 401 || error.response?.status === 403) {
       // 인증 실패 시 로그인 페이지로 리다이렉트
       localStorage.removeItem('accessToken')
-      window.location.href = '/login'
+      // Vue Router를 사용한 안전한 네비게이션
+      if (window.app && window.app.$router) {
+        window.app.$router.push('/login')
+      } else {
+        window.location.href = '/login'
+      }
     }
     return Promise.reject(error)
   }

--- a/frontend/src/api/plan.js
+++ b/frontend/src/api/plan.js
@@ -1,0 +1,131 @@
+import { localAxios } from '@/utils/http-commons'
+
+const planAPiClient = localAxios()
+
+// 요청 인터셉터 (인증 토큰 추가)
+planAPiClient.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('accessToken')
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`
+    }
+    return config
+  },
+  (error) => {
+    return Promise.reject(error)
+  }
+)
+
+// 응답 인터셉터 (에러 처리)
+planAPiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401 || error.response?.status === 403) {
+      // 인증 실패 시 로그인 페이지로 리다이렉트
+      localStorage.removeItem('accessToken')
+      window.location.href = '/login'
+    }
+    return Promise.reject(error)
+  }
+)
+
+export const planService = {
+  /**
+   * 여행 계획 리스트 조회 (공개 + 본인 private 계획)
+   * @returns {Promise} 여행 계획 리스트
+   */
+  getAllPlans() {
+    return planAPiClient.get('/plan')
+  },
+
+  /**
+   * 사용자가 생성한 여행 계획 리스트 조회
+   * @returns {Promise} 사용자 여행 계획 리스트
+   */
+  getUserPlans() {
+    return planAPiClient.get('/plan/user')
+  },
+
+  /**
+   * 여행 계획 상세 조회
+   * @param {number} planId - 여행 계획 ID
+   * @returns {Promise} 여행 계획 상세 정보
+   */
+  getPlanDetail(planId) {
+    return planAPiClient.get(`/plan/${planId}`)
+  },
+
+  /**
+   * 여행 계획 생성
+   * @param {Object} planData - 여행 계획 데이터
+   * @returns {Promise} 생성된 여행 계획 정보
+   */
+  createPlan(planData) {
+    return planAPiClient.post('/plan', planData)
+  },
+
+  /**
+   * 여행 계획 수정
+   * @param {number} planId - 여행 계획 ID
+   * @param {Object} planData - 수정할 여행 계획 데이터
+   * @returns {Promise} 수정된 여행 계획 정보
+   */
+  updatePlan(planId, planData) {
+    return planAPiClient.put(`/plan/${planId}`, planData)
+  },
+
+  /**
+   * 여행 계획 삭제
+   * @param {number} planId - 여행 계획 ID
+   * @returns {Promise} 삭제 결과
+   */
+  deletePlan(planId) {
+    return planAPiClient.delete(`/plan/${planId}`)
+  },
+
+  /**
+   * 여행 계획 좋아요 추가
+   * @param {number} planId - 여행 계획 ID
+   * @returns {Promise} 좋아요 추가 결과
+   */
+  addLike(planId) {
+    return planAPiClient.post(`/plan/${planId}/like`)
+  },
+
+  /**
+   * 여행 계획 좋아요 삭제
+   * @param {number} planId - 여행 계획 ID
+   * @returns {Promise} 좋아요 삭제 결과
+   */
+  removeLike(planId) {
+    return planAPiClient.delete(`/plan/${planId}/like`)
+  },
+
+  /**
+   * 여행 계획 북마크 추가
+   * @param {number} planId - 여행 계획 ID
+   * @returns {Promise} 북마크 추가 결과
+   */
+  addBookmark(planId) {
+    return planAPiClient.post(`/plan/${planId}/bookmark`)
+  },
+
+  /**
+   * 여행 계획 북마크 삭제
+   * @param {number} planId - 여행 계획 ID
+   * @returns {Promise} 북마크 삭제 결과
+   */
+  removeBookmark(planId) {
+    return planAPiClient.delete(`/plan/${planId}/bookmark`)
+  },
+
+  /**
+   * 북마크된 여행 계획 목록 조회
+   * @returns {Promise} 북마크된 여행 계획 리스트
+   */
+  getBookmarkedPlans() {
+    return planAPiClient.get('/plan/bookmarks')
+  }
+}
+
+export default planService

--- a/frontend/src/components/layouts/LayoutNavi.vue
+++ b/frontend/src/components/layouts/LayoutNavi.vue
@@ -122,7 +122,7 @@ const mobileMenuOpen = ref(false)
 
 // 메뉴 항목 정의
 const menuItems = ref([
-  { label: '일정', path: '/plan', icon: 'pi pi-calendar' },
+  { label: '일정', path: '/plan/dashboard', icon: 'pi pi-calendar' },
   { label: '여행지', path: '/attraction', icon: 'pi pi-map-marker' },
   { label: '게시판', path: '/board', icon: 'pi pi-users' },
 ])

--- a/frontend/src/components/views/plan/AddPlanCard.vue
+++ b/frontend/src/components/views/plan/AddPlanCard.vue
@@ -1,0 +1,19 @@
+<template>
+  <div 
+    class="rounded-2xl flex items-center justify-center cursor-pointer transition-all duration-300 border-2 border-dashed border-white/50 hover:-translate-y-1 hover:shadow-xl"
+    style="background: linear-gradient(135deg, #FF80CF 0%, #FFD900 100%); min-height: 280px;"
+    @click="$emit('click')"
+  >
+    <div class="flex flex-col items-center gap-3 text-white">
+      <div class="text-5xl font-light leading-none">+</div>
+      <span class="text-base font-semibold">일정 추가</span>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AddPlanCard',
+  emits: ['click']
+}
+</script>

--- a/frontend/src/components/views/plan/PlanCard.vue
+++ b/frontend/src/components/views/plan/PlanCard.vue
@@ -1,0 +1,200 @@
+<template>
+  <div 
+    class="bg-white rounded-2xl overflow-hidden shadow-lg transition-all duration-300 cursor-pointer border-2 border-transparent hover:-translate-y-1 hover:border-[#00EDB3]"
+    style="box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);"
+    @click="$emit('click', plan)"
+  >
+    <div 
+      class="relative w-full flex items-center justify-center overflow-hidden"
+      style="height: 180px; background: linear-gradient(135deg, #6FBBFF 0%, #00EDB3 100%);"
+    >
+      <img v-if="plan.image" :src="plan.image" :alt="plan.title" class="w-full h-full object-cover" />
+      <div v-else class="w-full h-full bg-gray-200 flex items-center justify-center text-gray-400 text-base font-medium">
+        <span>400 × 180</span>
+      </div>
+      <div class="absolute top-3 right-3 bg-black/60 px-3 py-1.5 rounded-full backdrop-blur-sm">
+        <span class="text-white text-xs font-medium">{{ getDuration() }}</span>
+      </div>
+    </div>
+    
+    <div class="p-5">
+      <h3 class="text-base font-semibold text-gray-900 mb-3 leading-snug line-clamp-2">
+        {{ plan.title }}
+      </h3>
+      
+      <div class="flex flex-col gap-1 mb-3">
+        <span class="text-sm text-gray-600 font-medium">{{ getLocationText() }}</span>
+        <span class="text-xs text-gray-400">{{ getDateRange() }}</span>
+      </div>
+      
+      <div class="flex gap-3 mb-3 text-xs text-gray-500">
+        <span class="flex items-center gap-1">조회 {{ plan.viewCount }}</span>
+        <span class="flex items-center gap-1">좋아요 {{ plan.likeCount }}</span>
+      </div>
+      
+      <div class="flex justify-between items-center">
+        <span 
+          class="px-3 py-1 rounded-full text-xs font-medium"
+          :class="getStatusBadgeClass()"
+        >
+          {{ getStatusText() }}
+        </span>
+        
+        <div class="flex gap-2 items-center text-sm">
+          <button 
+            @click.stop="toggleBookmark" 
+            class="p-1 rounded transition-colors hover:bg-gray-100 disabled:opacity-50"
+            :disabled="bookmarkLoading"
+          >
+            <span v-if="plan.bookmarked" class="text-[#FFD900]">★</span>
+            <span v-else class="text-gray-300">☆</span>
+          </button>
+          
+          <button 
+            @click.stop="toggleLike" 
+            class="p-1 rounded transition-colors hover:bg-gray-100 disabled:opacity-50"
+            :disabled="likeLoading"
+          >
+            <span class="transition-colors" :class="plan.liked ? 'text-[#FF80CF]' : 'text-gray-300'">♥</span>
+          </button>
+          
+          <span v-if="plan.public" class="text-[#00EDB3]">🌐</span>
+          <span v-else class="text-gray-400">🔒</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { planService } from '@/api/plan'
+
+export default {
+  name: 'TravelPlanCard',
+  props: {
+    plan: {
+      type: Object,
+      required: true
+    }
+  },
+  emits: ['click', 'update'],
+  data() {
+    return {
+      bookmarkLoading: false,
+      likeLoading: false
+    }
+  },
+  methods: {
+    getDuration() {
+      const start = new Date(this.plan.startDate);
+      const end = new Date(this.plan.endDate);
+      const diffTime = Math.abs(end - start);
+      const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24)) + 1;
+      return `${diffDays - 1}박 ${diffDays}일`;
+    },
+    getLocationText() {
+      if (this.plan.title.includes('제주')) return '제주도';
+      if (this.plan.title.includes('서울')) return '서울';
+      if (this.plan.title.includes('부산')) return '부산';
+      return '여행지';
+    },
+    getDateRange() {
+      const start = new Date(this.plan.startDate);
+      const end = new Date(this.plan.endDate);
+      const formatDate = (date) => {
+        return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')}`;
+      };
+      return `${formatDate(start)} - ${formatDate(end)}`;
+    },
+    getStatusClass() {
+      const today = new Date();
+      const startDate = new Date(this.plan.startDate);
+      const endDate = new Date(this.plan.endDate);
+      
+      if (today < startDate) return 'upcoming';
+      if (today >= startDate && today <= endDate) return 'ongoing';
+      return 'completed';
+    },
+    getStatusText() {
+      const statusClass = this.getStatusClass();
+      const statusMap = {
+        upcoming: '예정됨',
+        ongoing: '진행중',
+        completed: '완료됨'
+      };
+      return statusMap[statusClass];
+    },
+    getStatusBadgeClass() {
+      const statusClass = this.getStatusClass();
+      const baseClass = 'bg-gray-100 text-gray-600';
+      
+      switch(statusClass) {
+        case 'upcoming':
+          return 'text-[#6FBBFF] bg-blue-50';
+        case 'ongoing':
+          return 'text-[#FFD900] bg-yellow-50';
+        case 'completed':
+          return 'text-[#00EDB3] bg-green-50';
+        default:
+          return baseClass;
+      }
+    },
+    async toggleBookmark() {
+      if (this.bookmarkLoading) return;
+      
+      this.bookmarkLoading = true;
+      try {
+        if (this.plan.bookmarked) {
+          await planService.removeBookmark(this.plan.planId);
+        } else {
+          await planService.addBookmark(this.plan.planId);
+        }
+        
+        this.$emit('update', {
+          ...this.plan,
+          bookmarked: !this.plan.bookmarked
+        });
+      } catch (error) {
+        console.error('북마크 처리 중 오류가 발생했습니다:', error);
+      } finally {
+        this.bookmarkLoading = false;
+      }
+    },
+    async toggleLike() {
+      if (this.likeLoading) return;
+      
+      this.likeLoading = true;
+      try {
+        if (this.plan.liked) {
+          await planService.removeLike(this.plan.planId);
+        } else {
+          await planService.addLike(this.plan.planId);
+        }
+        
+        this.$emit('update', {
+          ...this.plan,
+          liked: !this.plan.liked,
+          likeCount: this.plan.liked ? this.plan.likeCount - 1 : this.plan.likeCount + 1
+        });
+      } catch (error) {
+        console.error('좋아요 처리 중 오류가 발생했습니다:', error);
+      } finally {
+        this.likeLoading = false;
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.hover\:shadow-lg:hover {
+  box-shadow: 0 8px 24px rgba(0, 237, 179, 0.15);
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -10,6 +10,20 @@ const router = createRouter({
       children: [
         { path: '', name: 'main', component: () => import('@/views/MainView.vue') },
         { path: 'login', name: 'login', component: () => import('@/views/LoginView.vue') },
+        { 
+          path: 'plan', 
+          children: [{
+            path: 'dashboard',
+            name: 'plan-dashboard',
+            component: () => import('@/views/PlanDashboardView.vue')
+          },
+          {
+            path: 'create',
+            name: 'plan-create',
+            component: () => import('@/views/PlanView.vue')
+          }
+          ]
+        },
       ],
     },
   ],

--- a/frontend/src/utils/http-commons.js
+++ b/frontend/src/utils/http-commons.js
@@ -5,8 +5,8 @@ const { VITE_API_BASE_URL } = import.meta.env
 // local vue api axios instance
 const localAxios = ()=>{
   const instance = axios.create({
-    baseURL: VITE_API_BASE_URL,
-    // baseURL: "http://localhost:8080",
+    // baseURL: VITE_API_BASE_URL,
+    baseURL: "http://localhost:8080/api",
     headers: {
       'Content-Type': 'application/json;charset=utf-8'
     }

--- a/frontend/src/views/PlanDashboardView.vue
+++ b/frontend/src/views/PlanDashboardView.vue
@@ -1,0 +1,201 @@
+<template>
+  <div class="flex">
+    <!-- 왼쪽 사이드바 -->
+    <aside class="w-64 bg-white border-r border-gray-200 flex-shrink-0">
+      <div class="p-6">
+        <!-- 사이드바 메뉴 -->
+        <nav class="space-y-2">
+          <button
+            @click="switchTab('myPlans')"
+            :class="[
+              'w-full flex items-center px-4 py-3 text-left rounded-lg transition-colors text-sm font-medium',
+              activeTab === 'myPlans' 
+                ? 'bg-[#00EDB3] text-white' 
+                : 'text-gray-700 hover:bg-gray-100'
+            ]"
+          >
+            <svg class="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z"/>
+              <path fill-rule="evenodd" d="M4 5a2 2 0 012-2v1a1 1 0 001 1h6a1 1 0 001-1V3a2 2 0 012 2v6.5a1.5 1.5 0 01-1.5 1.5h-7A1.5 1.5 0 014 11.5V5z" clip-rule="evenodd"/>
+            </svg>
+            내가 만든 일정
+          </button>
+
+          <button
+            @click="switchTab('bookmarks')"
+            :class="[
+              'w-full flex items-center px-4 py-3 text-left rounded-lg transition-colors text-sm font-medium',
+              activeTab === 'bookmarks' 
+                ? 'bg-[#00EDB3] text-white' 
+                : 'text-gray-700 hover:bg-gray-100'
+            ]"
+          >
+            <svg class="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 20 20">
+              <path d="M5 4a2 2 0 012-2h6a2 2 0 012 2v14l-5-2.5L5 18V4z"/>
+            </svg>
+            북마크
+          </button>
+        </nav>
+      </div>
+    </aside>
+
+    <!-- 오른쪽 컨텐츠 영역 -->
+    <main class="flex-1 p-6 bg-white">
+      <!-- 페이지 제목 -->
+      <div class="mb-6">
+        <h1 class="text-2xl font-bold text-gray-900">{{ getPageTitle() }}</h1>
+      </div>
+
+      <!-- 로딩 상태 -->
+      <div v-if="loading" class="flex flex-col items-center justify-center py-20 gap-4">
+        <div class="w-8 h-8 border-4 border-gray-200 border-t-[#00EDB3] rounded-full animate-spin"></div>
+        <span class="text-gray-600">데이터를 불러오는 중...</span>
+      </div>
+
+      <!-- 에러 상태 -->
+      <div v-else-if="error" class="flex flex-col items-center justify-center py-20 gap-4 text-red-500">
+        <span>{{ error }}</span>
+        <button 
+          @click="fetchData" 
+          class="px-4 py-2 bg-[#00EDB3] text-white rounded-lg hover:bg-[#00c49a] transition-colors"
+        >
+          다시 시도
+        </button>
+      </div>
+
+      <!-- 빈 상태 (북마크가 없을 때) -->
+      <div v-else-if="activeTab === 'bookmarks' && plans.length === 0" class="text-center py-20">
+        <div class="text-6xl mb-4">📌</div>
+        <h3 class="text-xl font-semibold text-gray-900 mb-2">북마크된 여행 계획이 없습니다</h3>
+        <p class="text-gray-600 mb-6">마음에 드는 여행 계획을 북마크해보세요</p>
+        <button 
+          @click="switchTab('myPlans')"
+          class="px-6 py-3 bg-[#00EDB3] text-white rounded-lg hover:bg-[#00c49a] transition-colors"
+        >
+          내 일정 보기
+        </button>
+      </div>
+
+      <!-- 여행 계획 그리드 -->
+      <div v-else class="grid gap-6" style="grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));">
+        <TravelPlanCard
+          v-for="plan in plans"
+          :key="plan.planId"
+          :plan="plan"
+          @click="openPlan"
+          @update="updatePlan"
+        />
+        
+        <!-- 내가 만든 일정 탭에서만 추가 카드 표시 -->
+        <AddPlanCard v-if="activeTab === 'myPlans'" @click="addNewPlan" />
+      </div>
+    </main>
+  </div>
+</template>
+
+<script>
+import { planService } from '@/api/plan'
+import TravelPlanCard from '@/components/views/plan/PlanCard.vue'
+import AddPlanCard from '@/components/views/plan/AddPlanCard.vue'
+
+export default {
+  name: 'PlanDashboardView',
+  components: {
+    TravelPlanCard,
+    AddPlanCard
+  },
+  data() {
+    return {
+      activeTab: 'myPlans', // 'myPlans' 또는 'bookmarks'
+      plans: [], // 현재 표시되는 계획들
+      loading: false,
+      error: null
+    }
+  },
+  mounted() {
+    this.fetchData();
+  },
+  methods: {
+    // 탭 전환
+    switchTab(tab) {
+      if (this.activeTab !== tab) {
+        this.activeTab = tab;
+        this.fetchData();
+      }
+    },
+    
+    // 페이지 제목 가져오기
+    getPageTitle() {
+      return this.activeTab === 'myPlans' ? '내가 만든 일정' : '북마크';
+    },
+    
+    // 데이터 가져오기 (탭에 따라 다른 데이터)
+    async fetchData() {
+      this.loading = true;
+      this.error = null;
+      
+      try {
+        if (this.activeTab === 'myPlans') {
+          // 내가 만든 일정 가져오기
+          const response = await planService.getUserPlans();
+          this.plans = response.data;
+        } else if (this.activeTab === 'bookmarks') {
+          // 북마크된 일정 가져오기 (임시로 필터링, 실제로는 별도 API 필요)
+          // const response = await planService.getUserPlans();
+          // this.plans = response.data.filter(plan => plan.bookmarked);
+          
+          // 또는 별도의 북마크 API가 있다면:
+          const response = await planService.getBookmarkedPlans();
+          this.plans = response.data;
+        }
+      } catch (error) {
+        console.error('데이터를 불러오는데 실패했습니다:', error);
+        
+        if (error.response?.status === 401) {
+          this.error = '로그인이 필요합니다.';
+        } else if (error.response?.status === 403) {
+          this.error = '접근 권한이 없습니다.';
+        } else if (error.response?.status >= 500) {
+          this.error = '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+        } else {
+          this.error = '데이터를 불러오는데 실패했습니다. 다시 시도해주세요.';
+        }
+      } finally {
+        this.loading = false;
+      }
+    },
+    
+    // 여행 계획 열기
+    openPlan(plan) {
+      console.log('Opening plan:', plan);
+      this.$router.push(`/plan/${plan.planId}`);
+    },
+    
+    // 새 계획 추가
+    addNewPlan() {
+      console.log('Adding new plan');
+      this.$router.push('/plan/create');
+    },
+    
+    // 계획 업데이트 (북마크/좋아요 변경 시)
+    updatePlan(updatedPlan) {
+      const index = this.plans.findIndex(plan => plan.planId === updatedPlan.planId);
+      if (index !== -1) {
+        // 북마크 탭에서 북마크가 해제되면 목록에서 제거
+        if (this.activeTab === 'bookmarks' && !updatedPlan.bookmarked) {
+          this.plans.splice(index, 1);
+        } else {
+          this.plans.splice(index, 1, updatedPlan);
+        }
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+/* 추가 스타일이 필요한 경우 */
+.h-full {
+  height: calc(100vh - 120px); /* 헤더/푸터 높이 제외 */
+}
+</style>

--- a/frontend/src/views/PlanView.vue
+++ b/frontend/src/views/PlanView.vue
@@ -1,0 +1,7 @@
+<template>
+  <div></div>
+</template>
+
+<script setup></script>
+
+<style lang="scss" scoped></style>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #47 

## 🔀 반영 브랜치
ex) feature/47/plan_dashboard -> dev

## 📝 작업 내용
- [x] 내가 만든 일정들 조회
- [x] 북마크한 일정들 조회
- [x] 북마크한 일정들 가져오는 API 개발

## 📑 작업 상세 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 여행 일정 대시보드(PlanDashboardView) 화면이 추가되어, 내가 만든 일정과 북마크한 일정을 탭으로 구분해 확인할 수 있습니다.
  - 여행 일정 카드(PlanCard) 및 일정 추가 카드(AddPlanCard) 컴포넌트가 도입되어, 일정을 한눈에 보고 북마크/좋아요 등의 상호작용이 가능합니다.
  - 여행 일정 관련 API 서비스가 추가되어, 일정 조회·생성·수정·삭제·좋아요·북마크 기능을 지원합니다.
  - 북마크한 일정 목록 조회 기능이 백엔드 및 프론트엔드에 추가되었습니다.
  - 새로운 일정 생성 및 상세 페이지 라우팅이 추가되었습니다.

- **버그 수정 및 개선**
  - CORS 및 보안 설정이 개선되어 다양한 로컬 개발 환경에서의 접근성이 향상되었습니다.
  - Axios 기본 API 경로가 일관되게 "/api"로 통합되었습니다.

- **스타일 및 UI**
  - 네비게이션 메뉴의 "일정" 경로가 "/plan"에서 "/plan/dashboard"로 변경되었습니다.

- **기타**
  - 일부 컴포넌트 및 페이지 파일이 새로 추가되었으며, 향후 일정 상세 보기 등 추가 개발이 예정되어 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->